### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ jvectormap-rails
 
 Add it to your `Gemfile`:
 ```
-gem 'jvectormap-rails', '~> 1.0.0'
+gem 'jvectormap-rails'
 ```
 
 ### Usage


### PR DESCRIPTION
This version is on 2.0.0, sing the "~> 1.0.0" bundle specifier prevents this from bundling with rails 5+, removing this to prevent copy pasting the legacy specifier causing bundle dependency errors for people using the latest version of Rails